### PR TITLE
Fix for #19: Support for Delphi 10.2 and newer (implemented TGraphic.…

### DIFF
--- a/Compilers.inc
+++ b/Compilers.inc
@@ -108,6 +108,18 @@
 
 // Compiler defines not specific to a particlular platform.
 
+  {$ifdef VER330}
+    {$define COMPILER_26}
+  {$endif VER330}
+
+  {$ifdef VER320}
+    {$define COMPILER_25}
+  {$endif VER320}
+
+  {$ifdef VER310}
+    {$define COMPILER_24}
+  {$endif VER310}
+
   {$ifdef VER300}
     {$define COMPILER_23}
   {$endif VER300}
@@ -612,7 +624,19 @@
   {$define COMPILER_17_UP}
 {$ENDIF}
 
+{$IFDEF COMPILER_24}
+  {$define COMPILER_17_UP}
+{$ENDIF}
 
+{$IFDEF COMPILER_25}
+  {$define COMPILER_17_UP}
+  {$define COMPILER_25_UP}
+{$ENDIF}
+
+{$IFDEF COMPILER_26}
+  {$define COMPILER_17_UP}
+  {$define COMPILER_25_UP}
+{$ENDIF}
 
 {$IFDEF NEWER_COMPILER}
  {$define COMPILER_1_UP}

--- a/GraphicEx.pas
+++ b/GraphicEx.pas
@@ -232,6 +232,9 @@ type
     class function CanLoad(const FileName: string): Boolean; overload;
     class function CanLoad(const Memory: Pointer; Size: Int64): Boolean; overload; virtual;
     class function CanLoad(Stream: TStream): Boolean; overload;
+    {$IFDEF COMPILER_25_UP}
+    class function CanLoadFromStream(Stream: TStream): Boolean; override;
+    {$ENDIF}
     procedure LoadFromFile(const FileName: string); override;
     procedure LoadFromFileByIndex(const FileName: string; ImageIndex: Cardinal = 0);  virtual; //by default it
     //creates file mapping and then calls LoadFromMemory. But if we use TStream instead, we can want to override it...
@@ -2261,6 +2264,22 @@ begin
       end;
     end;
 end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+{$IFDEF COMPILER_25_UP}
+class function TGraphicExGraphic.CanLoadFromStream(Stream: TStream): Boolean;
+var
+  P: Int64;
+begin
+  P := Stream.Position;
+  try
+    Result := CanLoad(Stream);
+  finally
+    Stream.Position := P;
+  end;
+end;
+{$ENDIF}
 
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
…CanLoadFromStream by the help of the existing CanLoad implementation)

The enhancement in Compilers.inc does also silence some hints and warnings.